### PR TITLE
Remove Ktor coroutines recommendations that seem obsolete

### DIFF
--- a/topics/concurrency-and-coroutines.md
+++ b/topics/concurrency-and-coroutines.md
@@ -177,17 +177,6 @@ If you see `InvalidMutabilityException` related to a coroutine operation, it's v
 
 See a [complete example of using multithreaded coroutines in a KMM application](https://github.com/touchlab/KaMPKit).
 
-### Ktor and coroutines
-
-Follow these guidelines when integrating Ktor into your project:
-
-* Make sure that you use the single-threaded version of `kotlinx.coroutines` as a dependency for Ktor. Ktor 
-for macOS and iOS requires this version.
-* Make calls to Ktor from the main thread. 
-* If you're going to use Ktor and coroutines that cross threads, keep a separate `CoroutineScope` for Ktor. As a more complex 
-alternative, you can create a child `CoroutineScope` with an isolated `Job`. If `Job` gets frozen, Ktor will stop working. 
-See [this example](https://github.com/touchlab/KaMPKit/blob/master/shared/src/iosMain/kotlin/co/touchlab/kampkit/ktor/Platform.kt#L13) for details.
-
 ## Alternatives to `kotlinx-coroutines`
 
 There are a few alternative ways to run parallel code.


### PR DESCRIPTION
[Ktor 1.4.1](https://github.com/ktorio/ktor/releases/tag/1.4.1) depends on `kotlinx-coroutines-core:1.3.9-native-mt-2` so the advice of using the single thread coroutines is misleading at the moment. I'm not sure what the actual recommendation is. I'll let people more familiar with the matter update the doc if needed.