### PR TITLE
Update `packForXcode` to look for correct `target`

### DIFF
--- a/topics/discover-kmm-project.md
+++ b/topics/discover-kmm-project.md
@@ -365,7 +365,9 @@ the appropriate framework version to the specified location.
 task(packForXcode, type: Sync) {
     group = 'build'
     def mode = System.getenv('CONFIGURATION') ?: 'DEBUG'
-    def framework = kotlin.targets.ios.binaries.getFramework(mode)
+    def sdkName = System.getenv("SDK_NAME") ?: "iphonesimulator"
+    def targetName = "ios" + ((sdkName.startsWith("iphoneos")) ? "Arm64" : "X64")
+    def framework = kotlin.targets.getByName(targetName).binaries.getFramework(mode)
     inputs.property('mode', mode)
     dependsOn(framework.linkTask)
     def targetDir = new File(buildDir, 'xcode-frameworks')
@@ -381,7 +383,9 @@ task(packForXcode, type: Sync) {
 val packForXcode by tasks.creating(Sync::class) {
     group = "build"
     val mode = System.getenv("CONFIGURATION") ?: "DEBUG"
-    val framework = kotlin.targets.getByName<KotlinNativeTarget>("ios").binaries.getFramework(mode)
+    val sdkName = System.getenv("SDK_NAME") ?: "iphonesimulator"
+    val targetName = "ios" + if (sdkName.startsWith("iphoneos")) "Arm64" else "X64"
+    val framework = kotlin.targets.getByName<KotlinNativeTarget>(targetName).binaries.getFramework(mode)
     inputs.property("mode", mode)
     dependsOn(framework.linkTask)
     val targetDir = File(buildDir, "xcode-frameworks")


### PR DESCRIPTION
Current documentation seems to be out of date. Suggested snippet results with a build error as Gradle will look for `target` named `ios` which does not exist. The one that exists are `iosArm64` and `iosX64`.

Link to reproduction: https://github.com/wzieba/PackForXcodeBugReproduction/runs/2085994451?check_suite_focus=true#step:3:30

The highlighted line presents all of the possible targets at the moment of executing `packForXcode`.

----

Updated documentation contains snippet taken from the [Android Studio Canary 8 generated template of KMM project](https://github.com/wzieba/PackForXcodeBugReproduction/commit/2636513b484f1418754bb821f86528689b1f8612#diff-cf9ae3b1eb7273a914f22b1e6d22d8447f88df0e7245a5b856fb751e507b979bR50-R60) in Kotlin DSL. I've also updated Groovy snippet with the same logic.