### PR TITLE
update: mention Apple Silicon simulators in supported-platforms.md

### DIFF
--- a/topics/supported-platforms.md
+++ b/topics/supported-platforms.md
@@ -5,8 +5,8 @@ Kotlin Multiplatform Mobile (_KMM_) is an SDK designed to simplify creating mult
 
 * Android applications and libraries
 * [Android NDK](https://developer.android.com/ndk) on ARM32 and ARM64 platforms
-* Apple iOS on ARM64 (iPhone 5s and newer), ARM32 (earlier models) platforms, and desktop simulators
-* Apple watchOS on ARM64 (Apple Watch Series 4 and newer), ARM32 (earlier models) platforms, and desktop simulators
+* Apple iOS on ARM64 (iPhone 5s and newer), ARM32 (earlier models) platforms, and desktop simulators on both Intel-based and Apple Silicon platforms
+* Apple watchOS on ARM64 (Apple Watch Series 4 and newer), ARM32 (earlier models) platforms, and desktop simulators on both Intel-based and Apple Silicon platforms
 
 KMM is built on top of the [Kotlin Multiplatform](https://kotlinlang.org/docs/multiplatform.html) technology, 
 which supports other platforms inlcuding JavaScript, Linux, WebAssembly, and [more](https://kotlinlang.org/docs/mpp-dsl-reference.html#targets). 


### PR DESCRIPTION
Mention Apple Silicon simulators among supported platforms.
To merge upon 1.5.30 release.